### PR TITLE
remake(skill): remaking whole UI of skill page

### DIFF
--- a/res/langs/en.json
+++ b/res/langs/en.json
@@ -885,8 +885,8 @@
         "stats-title": "Statistiques",
         "informations-title": "Informations",
         "history-title": "History",
-        "history-show": "see entire history",
-        "history-activity": "Activity history (last 14 days)",
+        "history-show": "See entire history",
+        "history-activity": "Activity history",
         "category-title": "Category:"
     },
 

--- a/res/langs/en.json
+++ b/res/langs/en.json
@@ -136,8 +136,8 @@
         "xp": "XP",
         "level": "Level",
         "level-small": "Lvl",
-        "total": "Activities",
-        "total-hour": "Total hours",
+        "total": "Occurrences",
+        "total-hour": "Total time",
         "average": "AVERAGE {} XP/DAY",
         "me": "Me"
     },
@@ -879,15 +879,15 @@
 
     "skill": {
         "title": "Skill",
-        "text-author": "An idea from {}",
+        "text-author": "This skill was an idea from {}",
         "text-unallocated": "Competence unallocated",
         "text-no-xp": "This activity does not earn experience",
         "stats-title": "Statistiques",
         "informations-title": "Informations",
         "history-title": "History",
-        "history-show": "Show history",
-        "history-activity": "Activity history",
-        "text-add": "Add activity"
+        "history-show": "see entire history",
+        "history-activity": "Activity history (last 14 days)",
+        "category-title": "Category:"
     },
 
     "skills": {

--- a/res/langs/fr.json
+++ b/res/langs/fr.json
@@ -136,8 +136,8 @@
         "xp": "EXP",
         "level": "Niveau",
         "level-small": "Niv",
-        "total": "Activités",
-        "total-hour": "Heures totales",
+        "total": "Occurences",
+        "total-hour": "temps total",
         "average": "En moyenne {} exp/jour",
         "me": "Moi"
     },
@@ -879,15 +879,15 @@
 
     "skill": {
         "title": "Compétence",
-        "text-author": "Une idée de {}",
+        "text-author": "Cette compétence est une idée de {}",
         "text-unallocated": "Compétence désafectée",
         "text-no-xp": "Cette activité ne rapporte pas d'expérience",
         "stats-title": "Statistiques",
         "informations-title": "Informations",
         "history-title": "Historique",
-        "history-show": "Afficher l'historique",
-        "history-activity": "Historique d'activité",
-        "text-add": "Ajouter l'activité"
+        "history-show": "Voir l'historique complet",
+        "history-activity": "Historique (14 jours)",
+        "category-title": "Catégorie :"
     },
 
     "skills": {

--- a/res/langs/fr.json
+++ b/res/langs/fr.json
@@ -137,7 +137,7 @@
         "level": "Niveau",
         "level-small": "Niv",
         "total": "Occurences",
-        "total-hour": "temps total",
+        "total-hour": "Temps total",
         "average": "En moyenne {} exp/jour",
         "me": "Moi"
     },
@@ -886,7 +886,7 @@
         "informations-title": "Informations",
         "history-title": "Historique",
         "history-show": "Voir l'historique complet",
-        "history-activity": "Historique (14 jours)",
+        "history-activity": "Historique",
         "category-title": "Catégorie :"
     },
 

--- a/src/Interface/Components/LineChartSvg/back.js
+++ b/src/Interface/Components/LineChartSvg/back.js
@@ -93,22 +93,24 @@ class LineChartSvgBack extends React.Component {
 
     /** @param {number} layoutWidth */
     compute(layoutWidth) {
+        const { data, graphHeight } = this.props;
+
         let maxValue = 100;
-        if (this.props.data.length > 0) {
-            maxValue = Math.max(...this.props.data.map((d) => d.value)) * 1.05;
+        if (data.length > 0) {
+            maxValue = Math.max(...data.map((d) => d.value)) * 1.05;
         }
 
         const yAxisValues = this.getYAxisValues(maxValue);
 
-        const points = this.props.data.map((item, index) => {
-            const x = this.getXCoordinate(index, this.props.data.length, layoutWidth);
-            const y = this.props.graphHeight - this.scaleY(item.value, maxValue);
+        const points = data.map((item, index) => {
+            const x = this.getXCoordinate(index, data.length, layoutWidth);
+            const y = graphHeight - this.scaleY(item.value, maxValue);
             return { x, y };
         });
 
-        if (Array.isArray(this.props.data) && this.props.data.length > 1) {
-            this.firstDate = this.props.data[0].date;
-            this.lastDate = this.props.data[this.props.data.length - 1].date;
+        if (Array.isArray(data) && data.length > 1) {
+            this.firstDate = data[0].date;
+            this.lastDate = data[data.length - 1].date;
         }
 
         this.setState({ maxValue, points, yAxisValues, layoutWidth });

--- a/src/Interface/Components/LineChartSvg/back.js
+++ b/src/Interface/Components/LineChartSvg/back.js
@@ -22,14 +22,19 @@ const LineChartSvgProps = {
     graphHeight: 200,
 
     /** @type {boolean} */
-    isAreaChart: false
+    isAreaChart: false,
+
+    /** @type {number} Smoothness factor for curve (0 = straight lines, 0.5 = default/recommended, 1 = very smooth) */
+    smoothness: 0.5
 };
 
 class LineChartSvgBack extends React.Component {
     state = {
         layoutWidth: 0,
         maxValue: 0,
-        points: '',
+
+        /** @type {{ x: number, y: number }[]} */
+        points: [],
 
         /** @type {number[]} */
         yAxisValues: []
@@ -95,13 +100,11 @@ class LineChartSvgBack extends React.Component {
 
         const yAxisValues = this.getYAxisValues(maxValue);
 
-        const points = this.props.data
-            .map((item, index) => {
-                const x = this.getXCoordinate(index, this.props.data.length, layoutWidth);
-                const y = this.props.graphHeight - this.scaleY(item.value, maxValue); // Calculate the y-coordinate
-                return `${x},${y}`; // Return the coordinate pair for SVG polyline
-            })
-            .join(' ');
+        const points = this.props.data.map((item, index) => {
+            const x = this.getXCoordinate(index, this.props.data.length, layoutWidth);
+            const y = this.props.graphHeight - this.scaleY(item.value, maxValue);
+            return { x, y };
+        });
 
         if (Array.isArray(this.props.data) && this.props.data.length > 1) {
             this.firstDate = this.props.data[0].date;

--- a/src/Interface/Components/LineChartSvg/index.js
+++ b/src/Interface/Components/LineChartSvg/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { Svg, Polyline, Line, Text, Circle, Path } from 'react-native-svg';
+import { Svg, Line, Text, Circle, Path } from 'react-native-svg';
 
 import LineChartSvgBack from './back';
 import themeManager from 'Managers/ThemeManager';
+import { generateSmoothPath } from 'Utils/Svg';
 
 class LineChartSvg extends LineChartSvgBack {
     render() {
@@ -67,33 +68,37 @@ class LineChartSvg extends LineChartSvgBack {
     }
 
     renderChartContent() {
-        const { data, lineColor, graphHeight, isAreaChart } = this.props;
+        const { lineColor, graphHeight, isAreaChart, smoothness } = this.props;
         const { points, layoutWidth } = this.state;
 
-        if (points.length <= 1 || layoutWidth === 0) {
+        if (points.length === 0 || layoutWidth === 0) {
             return null;
         }
 
         // Colors
         const topLineColor = themeManager.GetColor(lineColor);
-        const fillColor = topLineColor + '30'; // Change this to the desired color for the line on top
+        const fillColor = topLineColor + '30';
 
         // Single point
-        if (data.length === 1) {
-            const [x, y] = points.split(',').map(Number);
-            return <Circle key={`point_single`} cx={x} cy={y} r='3' fill={topLineColor} />;
+        if (points.length === 1) {
+            return <Circle key={`point_single`} cx={points[0].x} cy={points[0].y} r='3' fill={topLineColor} />;
         }
 
-        // Area chart path for the filled area
-        const areaPath = `M${this.leftMargin},${graphHeight} L${points} L${layoutWidth},${graphHeight} Z`;
+        // Generate smooth curve path
+        const linePath = generateSmoothPath(points, smoothness);
+
+        // Area chart path - close the path to fill
+        const firstPoint = points[0];
+        const lastPoint = points[points.length - 1];
+        const areaPath = `${linePath} L${lastPoint.x},${graphHeight} L${firstPoint.x},${graphHeight} Z`;
 
         return (
             <>
                 {/* Area fill */}
                 {isAreaChart && <Path d={areaPath} fill={fillColor} />}
 
-                {/* Line on top */}
-                <Polyline points={points} fill='none' stroke={topLineColor} strokeWidth='3' />
+                {/* Smooth curve line */}
+                <Path d={linePath} fill='none' stroke={topLineColor} strokeWidth='3' />
             </>
         );
     }

--- a/src/Interface/Pages/Skill/back.js
+++ b/src/Interface/Pages/Skill/back.js
@@ -6,7 +6,6 @@ import user from 'Managers/UserManager';
 import langManager from 'Managers/LangManager';
 import dataManager from 'Managers/DataManager';
 
-import { AddActivity } from 'Interface/Widgets';
 import { GetDate } from 'Utils/Time';
 import { Round } from 'Utils/Functions';
 import { DateFormat } from 'Utils/Date';
@@ -211,15 +210,6 @@ class BackSkill extends PageBase {
             totalDuration += element.duration;
         }
         return Round(totalDuration / 60, 1);
-    };
-
-    addActivity = () => {
-        const { selectedSkill } = this.state;
-        const skillID = selectedSkill.ID;
-
-        this.fe.bottomPanel?.Open({
-            content: <AddActivity openSkillID={skillID} />
-        });
     };
 
     showHistory = () => {

--- a/src/Interface/Pages/Skill/index.js
+++ b/src/Interface/Pages/Skill/index.js
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { View, ScrollView } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
 
 import BackSkill from './back';
 import styles from './style';
 import langManager from 'Managers/LangManager';
-import themeManager from 'Managers/ThemeManager';
 
 import { Round } from 'Utils/Functions';
 import { Text, Icon, ProgressBar, Button, KPI } from 'Interface/Components';
@@ -30,36 +28,20 @@ class Skill extends BackSkill {
 
                     {/* Skill name and icon */}
                     <View style={styles.titleContainer}>
-                        <LinearGradient
-                            style={styles.gradient}
-                            colors={[
-                                themeManager.GetColor('main1', { opacity: 0.65 }),
-                                themeManager.GetColor('main1', { opacity: 0.25 })
-                            ]}
-                            start={{ x: 0, y: 0 }}
-                            end={{ x: 1, y: 0 }}
-                        >
-                            <View style={styles.activityView}>
-                                <Icon style={styles.activityIcon} xml={selectedSkill.xml} />
-                                <View style={styles.activityTextView}>
-                                    <Text
-                                        style={styles.activityText}
-                                    >{`${selectedSkill.name} - ${selectedSkill.category}`}</Text>
-                                    {!selectedSkill.enabled && (
-                                        <Text style={styles.skillUnallocated} color='warning'>
-                                            {lang['text-unallocated']}
-                                        </Text>
-                                    )}
-                                </View>
-                            </View>
-                        </LinearGradient>
-
-                        {/* Creator */}
-                        {selectedSkill.creator !== '' && (
-                            <Text style={styles.creator} color='secondary'>
-                                {selectedSkill.creator}
+                        <Icon style={styles.activityIcon} xml={selectedSkill.xml} size={40} />
+                        <View style={styles.activityTextView}>
+                            <Text style={styles.activityText} numberOfLines={1} ellipsizeMode='tail'>
+                                {selectedSkill.name}
                             </Text>
-                        )}
+                            <Text style={styles.categoryText} numberOfLines={1} ellipsizeMode='tail'>
+                                {lang['category-title']} {selectedSkill.category}
+                            </Text>
+                            {!selectedSkill.enabled && (
+                                <Text style={styles.skillUnallocated} color='warning'>
+                                    {lang['text-unallocated']}
+                                </Text>
+                            )}
+                        </View>
                     </View>
 
                     {/* Level and XP bar */}
@@ -68,8 +50,8 @@ class Skill extends BackSkill {
                             <>
                                 <ProgressBar color='main1' value={selectedSkill.xp} maxValue={selectedSkill.next} />
                                 <View style={styles.levelsView}>
-                                    <Text>{selectedSkill.level}</Text>
-                                    <Text>{`${txtCurrXp}/${txtNextXP} ${txtXP}`}</Text>
+                                    <Text fontSize={14}>{selectedSkill.level}</Text>
+                                    <Text fontSize={14} color='secondary'>{`${txtCurrXp}/${txtNextXP} ${txtXP}`}</Text>
                                 </View>
                             </>
                         ) : (
@@ -81,53 +63,47 @@ class Skill extends BackSkill {
                     <Text style={styles.title} color='border'>
                         {lang['informations-title']}
                     </Text>
-                    <View style={styles.kpiContainer}>
-                        <KPI containerStyle={styles.kpiLeft} title={langLevel['total']} value={history.length} />
-                        <KPI
-                            containerStyle={styles.kpiRight}
-                            title={langLevel['total-hour']}
-                            value={selectedSkill.totalDuration + ' ' + langTime['hours-min']}
-                        />
+                    <View style={styles.infoContainer}>
+                        <View style={styles.kpiContainer}>
+                            <KPI containerStyle={styles.kpiLeft} title={langLevel['total']} value={history.length} />
+                            <KPI
+                                containerStyle={styles.kpiRight}
+                                title={langLevel['total-hour']}
+                                value={selectedSkill.totalDuration + ' ' + langTime['hours-min']}
+                            />
+                        </View>
+
+                        {/* Skill use chart */}
+                        {selectedSkill.ID !== 0 && (
+                            <SkillChart
+                                // TODO : Update the graph more properly
+                                key={`activities-length-${history.length}`}
+                                style={styles.skillChart}
+                                skillID={selectedSkill.ID}
+                                chartWidth={300}
+                            />
+                        )}
+
+                        {/* History */}
+                        {history.length > 0 && (
+                            <Button
+                                style={styles.historyButton}
+                                appearance='outline'
+                                color='main1'
+                                onPress={this.showHistory}
+                            >
+                                {lang['history-show']}
+                            </Button>
+                        )}
                     </View>
 
-                    {/* Skill use chart */}
-                    <Text style={styles.title} color='border'>
-                        {lang['history-activity']}
-                    </Text>
-                    {selectedSkill.ID !== 0 && (
-                        <SkillChart
-                            // TODO : Update the graph more properly
-                            key={`activities-length-${history.length}`}
-                            style={styles.skillChart}
-                            skillID={selectedSkill.ID}
-                            chartWidth={300}
-                        />
-                    )}
-
-                    {/* History */}
-                    {history.length > 0 && (
-                        <Button
-                            style={styles.historyButton}
-                            appearance='uniform'
-                            color='main1'
-                            onPress={this.showHistory}
-                        >
-                            {lang['history-show']}
-                        </Button>
+                    {/* Creator */}
+                    {selectedSkill.creator !== '' && (
+                        <Text style={styles.creator} color='secondary'>
+                            {selectedSkill.creator}
+                        </Text>
                     )}
                 </ScrollView>
-
-                {/* Absolute add button */}
-                {selectedSkill.enabled && (
-                    <Button
-                        style={styles.addActivity}
-                        appearance='uniform'
-                        color='main2'
-                        onPress={this.addActivity}
-                        icon='add-outline'
-                        iconSize={30}
-                    />
-                )}
             </>
         );
     }

--- a/src/Interface/Pages/Skill/index.js
+++ b/src/Interface/Pages/Skill/index.js
@@ -30,10 +30,8 @@ class Skill extends BackSkill {
                     <View style={styles.titleContainer}>
                         <Icon style={styles.activityIcon} xml={selectedSkill.xml} size={40} />
                         <View style={styles.activityTextView}>
-                            <Text style={styles.activityText} numberOfLines={1} ellipsizeMode='tail'>
-                                {selectedSkill.name}
-                            </Text>
-                            <Text style={styles.categoryText} numberOfLines={1} ellipsizeMode='tail'>
+                            <Text style={styles.activityText}>{selectedSkill.name}</Text>
+                            <Text style={styles.categoryText}>
                                 {lang['category-title']} {selectedSkill.category}
                             </Text>
                             {!selectedSkill.enabled && (
@@ -76,7 +74,6 @@ class Skill extends BackSkill {
                         {/* Skill use chart */}
                         {selectedSkill.ID !== 0 && (
                             <SkillChart
-                                // TODO : Update the graph more properly
                                 key={`activities-length-${history.length}`}
                                 style={styles.skillChart}
                                 skillID={selectedSkill.ID}

--- a/src/Interface/Pages/Skill/style.js
+++ b/src/Interface/Pages/Skill/style.js
@@ -13,37 +13,37 @@ const styles = StyleSheet.create({
 
     // Skill card
     titleContainer: {
-        marginBottom: 24
-    },
-    gradient: {
-        borderRadius: 8
-    },
-    activityView: {
+        marginBottom: 12,
         flexDirection: 'row',
-        alignItems: 'center',
-        paddingVertical: 12,
-        paddingHorizontal: 24
+        alignItems: 'center'
     },
     activityIcon: {
         marginRight: 16
     },
     activityTextView: {
-        flex: 1
+        flex: 1,
+        alignItems: 'flex-start'
     },
     activityText: {
-        fontSize: 16,
+        fontSize: 24,
+        fontWeight: 'bold',
+        textAlign: 'left'
+    },
+    categoryText: {
+        fontSize: 14,
         textAlign: 'left'
     },
     skillUnallocated: {
-        fontSize: 16,
+        fontSize: 14,
         textAlign: 'left',
-        opacity: 0.7
+        opacity: 0.7,
+        marginTop: 2
     },
     creator: {
         marginTop: 6,
         marginRight: 6,
-        fontSize: 18,
-        textAlign: 'right'
+        fontSize: 16,
+        textAlign: 'center'
     },
 
     // XP bar & level
@@ -59,12 +59,17 @@ const styles = StyleSheet.create({
         paddingHorizontal: 6
     },
 
+    // Info
+    infoContainer: {
+        marginBottom: 12
+    },
+
     // KPIs
     kpiContainer: {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-between',
-        marginBottom: 24
+        marginBottom: 12
     },
     kpiLeft: {
         marginRight: 6
@@ -75,12 +80,12 @@ const styles = StyleSheet.create({
 
     // Skill chart
     skillChart: {
-        marginBottom: 24
+        marginBottom: 12
     },
 
     // History
     historyButton: {
-        marginBottom: 24
+        marginBottom: 12
     },
     historyTitle: {
         marginTop: 24,
@@ -102,16 +107,6 @@ const styles = StyleSheet.create({
         paddingVertical: 12,
         paddingHorizontal: 6,
         marginVertical: 2
-    },
-
-    // Add activity button
-    addActivity: {
-        position: 'absolute',
-        width: 'auto',
-        right: 24,
-        bottom: 24,
-        paddingVertical: 12,
-        paddingHorizontal: 12
     }
 });
 

--- a/src/Interface/Widgets/SkillChart/back.js
+++ b/src/Interface/Widgets/SkillChart/back.js
@@ -24,7 +24,10 @@ const SkillChartProps = {
     chartWidth: 300,
 
     /** @type {number} */
-    skillID: 0
+    skillID: 0,
+
+    /** @type {Date | null} */
+    startDate: null
 };
 
 class SkillChartBack extends React.Component {
@@ -38,7 +41,8 @@ class SkillChartBack extends React.Component {
 
     componentDidMount() {
         const lineColor = this.getLineColor(this.props.skillID);
-        const linesData = this.getDataFromSkillID(this.props.skillID);
+        const startDate = this.props.startDate || new Date(Date.now() - 14 * 24 * 60 * 60 * 1000); // default last two weeks
+        const linesData = this.getDataFromSkillID(this.props.skillID, startDate);
         const cleaningData = this.fillMissingDates(linesData);
 
         this.setState({
@@ -50,14 +54,23 @@ class SkillChartBack extends React.Component {
     /**
      * Get all the data from the skillID
      * @param {number} skillID
+     * @param {Date | null} startDate - Optional start date to filter activities from
      * @returns {LineData[]}
      */
-    getDataFromSkillID(skillID) {
+    getDataFromSkillID(skillID, startDate = null) {
         const dataFromBack = [];
 
         // get the datas here
         const userActivities = user.activities.Get();
-        const history = userActivities.filter((a) => a.skillID === skillID);
+        let history = userActivities.filter((a) => a.skillID === skillID);
+
+        // Filter by start date if provided
+        if (startDate !== null) {
+            history = history.filter((a) => {
+                const activityDate = GetDate(a.startTime);
+                return activityDate >= startDate;
+            });
+        }
 
         // go through the history and create one {activity: string, date: string, value: number}
         for (const element of history) {

--- a/src/Interface/Widgets/SkillChart/back.js
+++ b/src/Interface/Widgets/SkillChart/back.js
@@ -61,19 +61,18 @@ class SkillChartBack extends React.Component {
 
         // get the datas here
         const userActivities = user.activities.Get();
-        let history = userActivities.filter((a) => a.skillID === skillID);
-
-        // Filter by start date if provided
-        if (startDate !== null) {
-            history = history.filter((a) => {
-                const activityDate = GetDate(a.startTime);
-                return activityDate >= startDate;
-            });
-        }
+        const history = userActivities.filter((a) => a.skillID === skillID);
 
         // go through the history and create one {activity: string, date: string, value: number}
         for (const element of history) {
-            const date = DateToFormatString(GetDate(element.startTime));
+            const activityDate = GetDate(element.startTime);
+
+            // Filter by start date if provided
+            if (startDate !== null && activityDate < startDate) {
+                continue;
+            }
+
+            const date = DateToFormatString(activityDate);
             const index = dataFromBack.findIndex((item) => item.date === date);
             if (index !== -1) {
                 dataFromBack[index].value += element.duration;

--- a/src/Interface/Widgets/SkillChart/back.js
+++ b/src/Interface/Widgets/SkillChart/back.js
@@ -41,8 +41,7 @@ class SkillChartBack extends React.Component {
 
     componentDidMount() {
         const lineColor = this.getLineColor(this.props.skillID);
-        const startDate = this.props.startDate || new Date(Date.now() - 14 * 24 * 60 * 60 * 1000); // default last two weeks
-        const linesData = this.getDataFromSkillID(this.props.skillID, startDate);
+        const linesData = this.getDataFromSkillID(this.props.skillID, this.props.startDate);
         const cleaningData = this.fillMissingDates(linesData);
 
         this.setState({

--- a/src/Interface/Widgets/SkillChart/back.js
+++ b/src/Interface/Widgets/SkillChart/back.js
@@ -114,8 +114,8 @@ class SkillChartBack extends React.Component {
         }
 
         const allDates = new Set();
-        let earliestDate = null;
-        let latestDate = null;
+        let earliestDate = /** @type {Date | null} */ (null);
+        let latestDate = /** @type {Date | null} */ (null);
 
         // Gather all unique dates and find earliest/latest dates
         data.forEach((dataPoint) => {
@@ -134,12 +134,19 @@ class SkillChartBack extends React.Component {
             return data;
         }
 
+        const _earliestDate = earliestDate;
+        const _latestDate = latestDate;
+        const _dateIncrement = 1000 * 60 * 60 * 24; // One day in milliseconds
+
         // Calculate the range of dates
-        const dateRange = Array.from({ length: (latestDate - earliestDate) / (1000 * 60 * 60 * 24) + 1 }, (_, i) => {
-            const date = new Date(earliestDate);
-            date.setDate(date.getDate() + i);
-            return formatDate(date);
-        });
+        const dateRange = Array.from(
+            { length: (_latestDate.getTime() - _earliestDate.getTime()) / _dateIncrement + 1 },
+            (_, i) => {
+                const date = new Date(_earliestDate.getTime());
+                date.setDate(date.getDate() + i);
+                return formatDate(date);
+            }
+        );
 
         // Fill in missing dates
         const result = dateRange.map((date) => {
@@ -161,11 +168,16 @@ class SkillChartBack extends React.Component {
      */
     getLineColor = (skillID) => {
         const skill = dataManager.skills.GetByID(skillID);
+        if (skill === null) {
+            return 'black';
+        }
+
         const categoryID = skill.CategoryID;
         const category = dataManager.skills.GetCategoryByID(categoryID);
         if (category === null) {
             return 'black';
         }
+
         return category.Color;
     };
 }

--- a/src/Interface/Widgets/SkillChart/index.js
+++ b/src/Interface/Widgets/SkillChart/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 
 import styles from './style';
 import SkillChartBack from './back';
@@ -12,24 +13,30 @@ class SkillChart extends SkillChartBack {
     render() {
         const lang = langManager.curr['skill'];
 
-        const styleContainer = {
-            backgroundColor: themeManager.GetColor('dataBigKpi')
-        };
-
         return (
             <View>
-                <View style={[styleContainer, styles.container, this.props.style]}>
-                    <View style={styles.titleView}>
-                        <Text color='primary' fontSize={16} bold>
-                            {lang['history-activity']}
-                        </Text>
+                <LinearGradient
+                    style={[styles.container, this.props.style]}
+                    colors={[
+                        themeManager.GetColor('border', { opacity: 0.2 }),
+                        themeManager.GetColor('border', { opacity: 0.06 })
+                    ]}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                >
+                    <View style={styles.gradientInner}>
+                        <View style={styles.titleView}>
+                            <Text color='primary' fontSize={16} bold>
+                                {lang['history-activity']}
+                            </Text>
+                        </View>
+                        <LineChartSvg
+                            data={this.state.cleanedData}
+                            style={this.props.style}
+                            lineColor={this.state.lineColor}
+                        />
                     </View>
-                    <LineChartSvg
-                        data={this.state.cleanedData}
-                        style={this.props.style}
-                        lineColor={this.state.lineColor}
-                    />
-                </View>
+                </LinearGradient>
             </View>
         );
     }

--- a/src/Interface/Widgets/SkillChart/style.js
+++ b/src/Interface/Widgets/SkillChart/style.js
@@ -2,18 +2,16 @@ import { StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
     container: {
-        paddingTop: 10,
-        paddingHorizontal: 20,
-        paddingBottom: 0,
-        borderRadius: 20
+        borderRadius: 8
+    },
+    gradientInner: {
+        paddingTop: 18,
+        paddingHorizontal: 18
     },
     titleView: {
         alignItems: 'flex-start',
-        justifyContent: 'flex-start'
-    },
-    headerText: {
-        fontWeight: 'bold',
-        marginVertical: 10
+        justifyContent: 'flex-start',
+        marginBottom: 4
     }
 });
 

--- a/src/Utils/Svg.js
+++ b/src/Utils/Svg.js
@@ -1,0 +1,54 @@
+/**
+ * Generates a smooth SVG path with rounded corners (like border-radius)
+ * The curve stays within the bounds defined by the points - no overshoot
+ * @param {{ x: number, y: number }[]} points - Array of points
+ * @param {number} smoothness - Corner radius factor (0 = sharp corners, higher = more rounded)
+ * @returns {string} SVG path string
+ */
+function generateSmoothPath(points, smoothness) {
+    if (points.length < 2) return '';
+    if (points.length === 2) {
+        return `M${points[0].x},${points[0].y} L${points[1].x},${points[1].y}`;
+    }
+
+    // Start at first point
+    let path = `M${points[0].x},${points[0].y}`;
+
+    for (let i = 1; i < points.length - 1; i++) {
+        const prev = points[i - 1];
+        const curr = points[i];
+        const next = points[i + 1];
+
+        // Calculate distances to previous and next points
+        const distPrev = Math.sqrt((curr.x - prev.x) ** 2 + (curr.y - prev.y) ** 2);
+        const distNext = Math.sqrt((next.x - curr.x) ** 2 + (next.y - curr.y) ** 2);
+
+        // Radius is limited by half the distance to neighbors
+        const maxRadius = Math.min(distPrev, distNext) * 0.5;
+        const radius = maxRadius * Math.min(smoothness, 1);
+
+        // Direction vectors (normalized)
+        const dirPrevX = (curr.x - prev.x) / distPrev;
+        const dirPrevY = (curr.y - prev.y) / distPrev;
+        const dirNextX = (next.x - curr.x) / distNext;
+        const dirNextY = (next.y - curr.y) / distNext;
+
+        // Points where the rounding starts and ends
+        const startX = curr.x - dirPrevX * radius;
+        const startY = curr.y - dirPrevY * radius;
+        const endX = curr.x + dirNextX * radius;
+        const endY = curr.y + dirNextY * radius;
+
+        // Line to the start of the curve, then quadratic bezier to round the corner
+        path += ` L${startX},${startY}`;
+        path += ` Q${curr.x},${curr.y} ${endX},${endY}`;
+    }
+
+    // Line to the last point
+    const last = points[points.length - 1];
+    path += ` L${last.x},${last.y}`;
+
+    return path;
+}
+
+export { generateSmoothPath };


### PR DESCRIPTION
The whole skill page was remade, here are the elements changed : 
- icon, skill name and skill category : UI remade 
- xp bar : level text and xp text are smaller 
- KPIs : only the en/fr translation were changed 
- history background : 
   - one title was removed
   - for uniformity background color change to the same linear than KPI
   - for clarity, we only see data for 14 last days on this chart 
- see history button : 
   - text (en/fr) was changed for more clarity 
   - color was changed so now the only 2 clickable elements of this page are outlined gradient 
- add activity button absolute bottom right : deleted for clarity of goal of the page, it's now an entirely read only page, no way of confusion
- creator of the app : moved to the bottom of the page and text rewritten, it's not supposed to be that interesting so the bottom of the page seems logical, it's here, but discreet. 

Merci pour ta PR ❤️ -> De rien gros bg 

## Checklist PR
- [x] **Titre** clair et descriptif
- [x] **Description** détaillée des changements
- [x] **Screenshots** fournis pour les changements UI
